### PR TITLE
Create CI to run demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  run-demo:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test demo example
+      run: docker-compose up --remove-orphans --build --detach
+      


### PR DESCRIPTION
Talking with @jgpruitt, we thought it would be a great idea to add a CI workflow to run the demo as this project does not have tests.
First run [passed](https://github.com/timescale/opentelemetry-demo/runs/7023988638?check_suite_focus=true) 🎉 
