### PR TITLE
Enable Jaeger Service Performance Management (SPM) experimental feature

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       PROMSCALE_TRACING_OTLP_SERVER_ADDRESS: 0.0.0.0:9202
 
   jaeger:
-    image: jaegertracing/jaeger-query:1.30
+    image: jaegertracing/jaeger-query:1.35
     ports:
       - 16685:16685/tcp
       - 16686:16686/tcp
@@ -41,6 +41,8 @@ services:
     environment:
       SPAN_STORAGE_TYPE: grpc-plugin
       GRPC_STORAGE_SERVER: promscale:9202
+      METRICS_STORAGE_TYPE: prometheus
+      PROMETHEUS_SERVER_URL: http://promscale:9201
 
   grafana:
     build:
@@ -57,6 +59,7 @@ services:
   collector:
     build:
       context: ./instrumented/collector
+    command: --config /etc/otelcol/config.yaml
     ports:
       - 4317:4317/tcp
       - 4318:4318/tcp

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
 
   promscale:
-    image: "timescale/promscale:0.11.0"
+    image: "timescale/promscale:0.12.0"
     ports:
       - 9201:9201/tcp
       - 9202:9202/tcp

--- a/instrumented/collector/Dockerfile
+++ b/instrumented/collector/Dockerfile
@@ -1,2 +1,2 @@
-FROM otel/opentelemetry-collector:0.43.0
+FROM otel/opentelemetry-collector-contrib:0.54.0
 COPY config.yaml /etc/otelcol/config.yaml

--- a/instrumented/collector/config.yaml
+++ b/instrumented/collector/config.yaml
@@ -4,12 +4,26 @@ receivers:
       grpc:
       http:
 
+  # Dummy receiver that's never used, because a pipeline is required to have one.
+  otlp/spanmetrics:
+    protocols:
+      grpc:
+        endpoint: "localhost:12345"
+
 processors:
   batch:
+  spanmetrics:
+    metrics_exporter: prometheusremotewrite
+    dimensions_cache_size: 1000
+    aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"
 
 exporters:
   otlp:
     endpoint: promscale:9202
+    tls:
+      insecure: true
+  prometheusremotewrite:
+    endpoint: "http://promscale:9201/write"
     tls:
       insecure: true
 
@@ -20,5 +34,11 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [spanmetrics, batch]
       exporters: [otlp]
+
+    metrics:
+      # This receiver is just a dummy and never used.
+      # Added to pass validation requiring at least one receiver in a pipeline.
+      receivers: [otlp/spanmetrics]
+      exporters: [prometheusremotewrite]

--- a/instrumented/generator/generator.py
+++ b/instrumented/generator/generator.py
@@ -6,7 +6,7 @@ from flask import Flask
 import requests
 
 from opentelemetry import trace
-from opentelemetry.trace import StatusCode, Status
+from opentelemetry.trace import StatusCode, Status, SpanKind
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk.resources import Resource
@@ -121,8 +121,9 @@ def generate() -> str:
 
 @app.route('/')
 def generator():
-    password = generate()
-    return { 'password': password }
+    with tracer.start_as_current_span("/", kind = SpanKind.SERVER) as span:
+        password = generate()
+        return { 'password': password }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Configure Jaeger and the OTel Collector to enable [Jaeger SPM](https://www.jaegertracing.io/docs/1.35/spm/) experimental feature
